### PR TITLE
Add voice selection for speech notifications and update global instal…

### DIFF
--- a/.claude/hooks/notification.ts
+++ b/.claude/hooks/notification.ts
@@ -56,7 +56,14 @@ process.stdin.on("end", async () => {
       // Check if --speak flag is present and on macOS
       if (process.argv.includes("--speak") && os_platform === "darwin") {
         const message = "Your agent needs attention";
-        const cmd = `say "${message}"`;
+        
+        // Check for --voice flag
+        const voiceIndex = process.argv.indexOf("--voice");
+        const voice = voiceIndex !== -1 && voiceIndex + 1 < process.argv.length 
+          ? process.argv[voiceIndex + 1] 
+          : null;
+        
+        const cmd = voice ? `say -v "${voice}" "${message}"` : `say "${message}"`;
         
         exec(cmd, (err) => {
           if (err) {

--- a/.claude/hooks/stop.ts
+++ b/.claude/hooks/stop.ts
@@ -86,7 +86,14 @@ process.stdin.on('end', async () => {
     // Check if --speak flag is present and on macOS
     if (process.argv.includes('--speak') && os_platform === 'darwin') {
       const message = "Your agent has finished";
-      const cmd = `say "${message}"`;
+      
+      // Check for --voice flag
+      const voiceIndex = process.argv.indexOf("--voice");
+      const voice = voiceIndex !== -1 && voiceIndex + 1 < process.argv.length 
+        ? process.argv[voiceIndex + 1] 
+        : null;
+      
+      const cmd = voice ? `say -v "${voice}" "${message}"` : `say "${message}"`;
       
       exec(cmd, (err) => {
         if (err) {

--- a/.claude/hooks/subagent_stop.ts
+++ b/.claude/hooks/subagent_stop.ts
@@ -57,7 +57,14 @@ process.stdin.on("end", async () => {
     // Check if --speak flag is present and on macOS
     if (process.argv.includes("--speak") && os_platform === "darwin") {
       const message = "Your subagent has finished";
-      const cmd = `say "${message}"`;
+      
+      // Check for --voice flag
+      const voiceIndex = process.argv.indexOf("--voice");
+      const voice = voiceIndex !== -1 && voiceIndex + 1 < process.argv.length 
+        ? process.argv[voiceIndex + 1] 
+        : null;
+      
+      const cmd = voice ? `say -v "${voice}" "${message}"` : `say "${message}"`;
       
       exec(cmd, (err) => {
         if (err) {

--- a/.claude/settings-speech.json
+++ b/.claude/settings-speech.json
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx tsx .claude/hooks/notification.ts --notify --speak"
+            "command": "npx tsx .claude/hooks/notification.ts --notify --speak --voice Samantha"
           }
         ]
       }
@@ -39,7 +39,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx tsx .claude/hooks/stop.ts --chat --speak"
+            "command": "npx tsx .claude/hooks/stop.ts --chat --speak --voice Samantha"
           }
         ]
       }
@@ -50,7 +50,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx tsx .claude/hooks/subagent_stop.ts --speak"
+            "command": "npx tsx .claude/hooks/subagent_stop.ts --speak --voice Samantha"
           }
         ]
       }

--- a/scripts/merge-settings.js
+++ b/scripts/merge-settings.js
@@ -6,12 +6,12 @@ import path from 'path';
 
 // Get command line arguments
 const args = process.argv.slice(2);
-if (args.length < 2 || args.length > 3) {
-    console.error('Usage: node merge-settings.js <existing_file> <output_file> [speech]');
+if (args.length < 2 || args.length > 4) {
+    console.error('Usage: node merge-settings.js <existing_file> <output_file> [speech] [voice]');
     process.exit(1);
 }
 
-const [existingFile, outputFile, mode] = args;
+const [existingFile, outputFile, mode, voice] = args;
 const useSpeak = mode === 'speech';
 const home = os.homedir();
 
@@ -28,7 +28,7 @@ try {
     existing = {};
 }
 
-const speakFlag = useSpeak ? ' --speak' : '';
+const speakFlag = useSpeak ? ` --speak${voice ? ` --voice ${voice}` : ''}` : '';
 
 const new_hooks = {
     'PreToolUse': [],


### PR DESCRIPTION
Summary
  - Add voice selection support for macOS speech notifications
  - Update global installation script to prompt for voice
  preference
  - Modify all hooks to accept --voice parameter for custom voice
  selection

  Changes
  - Voice Selection: All three hooks (notification.ts, stop.ts,
  subagent_stop.ts) now support a --voice parameter to specify
  custom macOS voices
  - Installation Enhancement: install-global.sh now prompts users
  to choose a voice when selecting speech notifications on macOS
  - Settings Update: settings-speech.json includes Samantha voice
  as default example
  - Merge Script: merge-settings.js updated to handle voice
  parameter during installation

  Technical Details
  - Voice parameter is optional - falls back to system default if
  not provided
  - Voice selection only available on macOS (uses say -v command)
  - Installation script lists common voice options and validates
  macOS platform
  - Maintains backward compatibility with existing --speak flag